### PR TITLE
feat: retrieve actual id from sequence ids when creating instead of passing actual id to microreact

### DIFF
--- a/app/src/app/workspaces/create-workspace-from-microreact.tsx
+++ b/app/src/app/workspaces/create-workspace-from-microreact.tsx
@@ -5,7 +5,7 @@ import { AddIcon } from "@chakra-ui/icons";
 import { useMutation } from "redux-query-react";
 import { useLocation, Redirect } from "react-router-dom";
 import { useMemo } from "react";
-import { createWorkspace } from "./workspaces-query-configs";
+import { createWorkspaceFromSequenceIds } from "./workspaces-query-configs";
 
 export function CreateWorkspaceFromMicroreact() {
   const [name, setName] = React.useState("");
@@ -13,12 +13,14 @@ export function CreateWorkspaceFromMicroreact() {
   const searchParams = useMemo(() => new URLSearchParams(search), [search]);
   const [isSending, setIsSending] = React.useState(false);
   const [isCreated, setIsCreated] = React.useState(false);
-  const [isRequired, setIsRequired] = React.useState(false)
+  const [isRequired, setIsRequired] = React.useState(false);
 
   const [
     createWorkspaceQueryState,
     createWorkspaceMutation,
-  ] = useMutation((workspaceName: string, samples: string[]) => createWorkspace({ name: workspaceName, samples: samples }));
+  ] = useMutation((workspaceName: string, samples: string[]) =>
+    createWorkspaceFromSequenceIds({ name: workspaceName, samples: samples })
+  );
 
   const content = (
     <React.Fragment>
@@ -41,19 +43,19 @@ export function CreateWorkspaceFromMicroreact() {
         <Button
           leftIcon={<AddIcon />}
           onClick={() => {
-            if(!name){
-              setIsRequired(true)
-              setTimeout(() => setIsRequired(false), 250)
+            if (!name) {
+              setIsRequired(true);
+              setTimeout(() => setIsRequired(false), 250);
               return;
             }
-            setIsSending(true)
+            setIsSending(true);
             const ids = searchParams.get("ids");
             if (ids) {
               const idArr = ids.split(",");
-              createWorkspaceMutation(name, idArr );
-              setIsCreated(true)
-              setIsSending(false)
-              alert("Workspace created.")
+              createWorkspaceMutation(name, idArr);
+              setIsCreated(true);
+              setIsSending(false);
+              alert("Workspace created.");
             }
           }}
           disabled={isSending && !isCreated}

--- a/app/src/sap-client/apis/WorkspacesApi.ts
+++ b/app/src/sap-client/apis/WorkspacesApi.ts
@@ -40,6 +40,10 @@ export interface CreateWorkspaceRequest {
     createWorkspace?: CreateWorkspace;
 }
 
+export interface CreateWorkspaceFromSequenceIdsRequest {
+    createWorkspace?: CreateWorkspace;
+}
+
 export interface DeleteWorkspaceRequest {
     workspaceId: string;
 }
@@ -145,6 +149,48 @@ function createWorkspaceRaw<T>(requestParameters: CreateWorkspaceRequest, reques
 */
 export function createWorkspace<T>(requestParameters: CreateWorkspaceRequest, requestConfig?: runtime.TypedQueryConfig<T, void>): QueryConfig<T> {
     return createWorkspaceRaw(requestParameters, requestConfig);
+}
+
+/**
+ */
+function createWorkspaceFromSequenceIdsRaw<T>(requestParameters: CreateWorkspaceFromSequenceIdsRequest, requestConfig: runtime.TypedQueryConfig<T, void> = {}): QueryConfig<T> {
+    let queryParameters = null;
+
+
+    const headerParameters : runtime.HttpHeaders = {};
+
+    headerParameters['Content-Type'] = 'application/json';
+
+
+    const { meta = {} } = requestConfig;
+
+    meta.authType = ['bearer'];
+    const config: QueryConfig<T> = {
+        url: `${runtime.Configuration.basePath}/workspaces/create_from_sequence_ids`,
+        meta,
+        update: requestConfig.update,
+        queryKey: requestConfig.queryKey,
+        optimisticUpdate: requestConfig.optimisticUpdate,
+        force: requestConfig.force,
+        rollback: requestConfig.rollback,
+        options: {
+            method: 'POST',
+            headers: headerParameters,
+        },
+        body: queryParameters || CreateWorkspaceToJSON(requestParameters.createWorkspace),
+    };
+
+    const { transform: requestTransform } = requestConfig;
+    if (requestTransform) {
+    }
+
+    return config;
+}
+
+/**
+*/
+export function createWorkspaceFromSequenceIds<T>(requestParameters: CreateWorkspaceFromSequenceIdsRequest, requestConfig?: runtime.TypedQueryConfig<T, void>): QueryConfig<T> {
+    return createWorkspaceFromSequenceIdsRaw(requestParameters, requestConfig);
 }
 
 /**

--- a/bifrost/bifrost_queue_broker/common/config/column_config.py
+++ b/bifrost/bifrost_queue_broker/common/config/column_config.py
@@ -41,6 +41,8 @@ def columns() -> List[Dict[str, str]]:
     # build up dictionary of default configs
     openapi_columns = analysis.openapi_types.items()
     for attr, _ in openapi_columns:
+        if attr == "id":
+            continue
         cols.update({attr: gen_default_column(attr)})
     # apply configuration file on top
     with open(PATH + "/column-config.jsonc") as js_file:

--- a/openapi_specs/SOFI/SOFI.yaml
+++ b/openapi_specs/SOFI/SOFI.yaml
@@ -43,6 +43,20 @@ paths:
       tags:
         - workspaces
       x-openapi-router-controller: web.src.SAP.generated.controllers.workspaces_controller
+  /workspaces/create_from_sequence_ids:
+    post:
+      operationId: create_workspace_from_sequence_ids
+      requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateWorkspace"
+      responses:
+        '204':
+          description: "Workspace created."
+      tags:
+        - workspaces
+      x-openapi-router-controller: web.src.SAP.generated.controllers.workspaces_controller
   /workspace/clone:
     post:
       operationId: clone_workspace

--- a/web/openapi_specs/SOFI/SOFI.yaml
+++ b/web/openapi_specs/SOFI/SOFI.yaml
@@ -43,6 +43,20 @@ paths:
       tags:
         - workspaces
       x-openapi-router-controller: web.src.SAP.generated.controllers.workspaces_controller
+  /workspaces/create_from_sequence_ids:
+    post:
+      operationId: create_workspace_from_sequence_ids
+      requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateWorkspace"
+      responses:
+        '204':
+          description: "Workspace created."
+      tags:
+        - workspaces
+      x-openapi-router-controller: web.src.SAP.generated.controllers.workspaces_controller
   /workspace/clone:
     post:
       operationId: clone_workspace

--- a/web/src/SAP/common/config/column_config.py
+++ b/web/src/SAP/common/config/column_config.py
@@ -41,6 +41,8 @@ def columns() -> List[Dict[str, str]]:
     # build up dictionary of default configs
     openapi_columns = analysis.openapi_types.items()
     for attr, _ in openapi_columns:
+        if attr == "id":
+            continue
         cols.update({attr: gen_default_column(attr)})
     # apply configuration file on top
     with open(PATH + "/column-config.jsonc") as js_file:

--- a/web/src/SAP/generated/controllers/workspaces_controller.py
+++ b/web/src/SAP/generated/controllers/workspaces_controller.py
@@ -34,6 +34,21 @@ def create_workspace(user, token_info, create_workspace=None):  # noqa: E501
         create_workspace = CreateWorkspace.from_dict(connexion.request.get_json())  # noqa: E501
     return WorkspacesController.create_workspace(user, token_info, create_workspace)
 
+def create_workspace_from_sequence_ids(user, token_info, create_workspace=None):  # noqa: E501
+    """create_workspace_from_sequence_ids
+
+     # noqa: E501
+
+    :param create_workspace: 
+    :type create_workspace: dict | bytes
+
+    :rtype: None
+    """
+    if connexion.request.is_json:
+        from ..models import CreateWorkspace
+        create_workspace = CreateWorkspace.from_dict(connexion.request.get_json())  # noqa: E501
+    return WorkspacesController.create_workspace_from_sequence_ids(user, token_info, create_workspace)
+
 def delete_workspace(user, token_info, workspace_id):  # noqa: E501
     """delete_workspace
 

--- a/web/src/SAP/generated/models/__init__.py
+++ b/web/src/SAP/generated/models/__init__.py
@@ -28,6 +28,7 @@ from .lims_specific_metadata import LimsSpecificMetadata
 from .metadata_reload_request import MetadataReloadRequest
 from .metadata_reload_response import MetadataReloadResponse
 from .microreact_project import MicroreactProject
+from .microreact_url_response import MicroreactUrlResponse
 from .multi_upload_request import MultiUploadRequest
 from .nearest_neighbors_request import NearestNeighborsRequest
 from .nearest_neighbors_response import NearestNeighborsResponse

--- a/web/src/SAP/generated/openapi/openapi.yaml
+++ b/web/src/SAP/generated/openapi/openapi.yaml
@@ -659,6 +659,20 @@ paths:
       tags:
       - workspaces
       x-openapi-router-controller: web.src.SAP.generated.controllers.workspaces_controller
+  /workspaces/create_from_sequence_ids:
+    post:
+      operationId: create_workspace_from_sequence_ids
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateWorkspace'
+      responses:
+        "204":
+          description: Workspace created.
+      tags:
+      - workspaces
+      x-openapi-router-controller: web.src.SAP.generated.controllers.workspaces_controller
   /workspaces/{workspace_id}:
     delete:
       description: Delete an existing workspace

--- a/web/src/SAP/generated/test/test_workspaces_controller.py
+++ b/web/src/SAP/generated/test/test_workspaces_controller.py
@@ -61,6 +61,28 @@ class TestWorkspacesController(BaseTestCase):
         self.assert200(response,
                        'Response body is : ' + response.data.decode('utf-8'))
 
+    def test_create_workspace_from_sequence_ids(self):
+        """Test case for create_workspace_from_sequence_ids
+
+        
+        """
+        create_workspace = {
+  "name" : "name",
+  "samples" : [ "samples", "samples" ]
+}
+        headers = { 
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer special-key',
+        }
+        response = self.client.open(
+            '/api/workspaces/create_from_sequence_ids',
+            method='POST',
+            headers=headers,
+            data=json.dumps(create_workspace),
+            content_type='application/json')
+        self.assert200(response,
+                       'Response body is : ' + response.data.decode('utf-8'))
+
     def test_delete_workspace(self):
         """Test case for delete_workspace
 

--- a/web/src/SAP/src/controllers/WorkspacesController.py
+++ b/web/src/SAP/src/controllers/WorkspacesController.py
@@ -4,6 +4,7 @@ from ..repositories.workspaces import get_workspaces as get_workspaces_db
 from ..repositories.workspaces import delete_workspace as delete_workspace_db
 from ..repositories.workspaces import delete_workspace_sample as delete_workspace_sample_db
 from ..repositories.workspaces import create_workspace as create_workspace_db
+from ..repositories.workspaces import create_workspace_from_sequence_ids as create_workspace_from_sequence_ids_db
 from ..repositories.workspaces import clone_workspace as clone_workspace_db
 from ..repositories.workspaces import update_workspace as update_workspace_db
 from ..repositories.workspaces import get_workspace as get_workspace_db
@@ -22,6 +23,13 @@ def create_workspace(user, token_info, body):
     if res.upserted_id:
         return jsonify({"id": str(res.upserted_id)})
 
+    return jsonify(body)
+
+def create_workspace_from_sequence_ids(user, token_info, body):
+    res = create_workspace_from_sequence_ids_db(user, body)
+    
+    if res.upserted_id:
+        return jsonify({"id": str(res.upserted_id)})
     return jsonify(body)
 
 def clone_workspace(user, token_info, body):

--- a/web/src/SAP/src/repositories/samples.py
+++ b/web/src/SAP/src/repositories/samples.py
@@ -11,3 +11,12 @@ def get_single_sample(sample_id: str) -> Dict[str, Any]:
     mydb = conn[DB_NAME]
     samples = mydb[SAMPLES_COL_NAME]
     return samples.find_one(ObjectId(sample_id))
+
+def get_sample_id_from_sequence_id(sequence_id: str) -> str:
+    conn = get_connection()
+    mydb = conn[DB_NAME]
+    samples = mydb[SAMPLES_COL_NAME]
+    id = str(samples.find({"categories.sample_info.summary.sofi_sequence_id": sequence_id}, {"_id": 1}).sort("metadata.updated_at", -1).next()["_id"])
+    print(f"Found {id} for seq: {sequence_id}")
+    
+    return id

--- a/web/src/SAP/src/repositories/workspaces.py
+++ b/web/src/SAP/src/repositories/workspaces.py
@@ -9,6 +9,7 @@ from ...src.repositories.analysis import (
 from ...common.database import get_collection, WORKSPACES_COL_NAME
 from ...generated.models import CreateWorkspace
 from ...generated.models import CloneWorkspace
+from ..repositories.samples import get_sample_id_from_sequence_id
 import io
 from flask import send_file
 
@@ -100,6 +101,18 @@ def create_workspace(user: str, workspace: CreateWorkspace):
         {"created_by": user, "name": workspace.name}, {"$set": record}, upsert=True
     )
 
+def create_workspace_from_sequence_ids(user: str, workspace: CreateWorkspace):
+    workspaces = get_collection(WORKSPACES_COL_NAME)
+    
+    if workspace.samples is None:
+        workspace.samples = []
+        
+    workspace.samples = list(map(lambda x: get_sample_id_from_sequence_id(x), workspace.samples))
+        
+    record = {**workspace.to_dict(), "created_by": user}
+    return workspaces.update_one(
+        {"created_by": user, "name": workspace.name}, {"$set": record}, upsert=True
+    )
 
 def clone_workspace(user: str, cloneWorkspaceInfo: CloneWorkspace):
     workspaces = get_collection(WORKSPACES_COL_NAME)


### PR DESCRIPTION
- implement new backend endpoint `create_workspace_from_sequence_ids` which queries db for actual id
- revert back to skipping actual id-column when viewing/sending sample columns