### PR TITLE
Prevent that BioAPI crashes when jobs take more than two seconds

### DIFF
--- a/web/src/SAP/src/controllers/MicroreactController.py
+++ b/web/src/SAP/src/controllers/MicroreactController.py
@@ -70,13 +70,18 @@ def send_to_microreact(user, token_info, body: NewMicroreactProjectRequestData):
             time.sleep(2)
             distance_get_api_response = (
                 api_instance.dmx_result_v1_distance_calculations_dc_id_get(
-                    distance_job_id
+                    distance_job_id,
+                    level='basic'
                 )
             )
             status = distance_get_api_response.status.value
 
         if status == "error":
             return abort(500)
+        
+        # Note:
+        # SOFI does not need the actual distance matrix for now, so no need to request with level='full'.
+        # When SOFI has to send the distance matrix to Microreact another GET call with level='full' will be necessary.
 
         # Trees
         api_instance = TreesApi(api_client)

--- a/web/src/SAP/src/controllers/MicroreactController.py
+++ b/web/src/SAP/src/controllers/MicroreactController.py
@@ -98,13 +98,21 @@ def send_to_microreact(user, token_info, body: NewMicroreactProjectRequestData):
             while status == "init":
                 time.sleep(2)
                 trees_get_api_response = api_instance.hc_tree_result_v1_trees_tc_id_get(
-                    job_id
+                    job_id,
+                    level="basic"
                 )
                 status = trees_get_api_response.status.value
-                result = trees_get_api_response.result
 
             if status == "error":
                 return abort(500, description=result)
+            
+            if status == "completed":
+                trees_get_api_response = api_instance.hc_tree_result_v1_trees_tc_id_get(
+                    job_id,
+                    level="full"
+                )
+            
+            result = trees_get_api_response.result
 
             tree_calcs.append({"method": tree_method, "result": result})
 

--- a/web/src/SAP/src/controllers/NearestNeighborsController.py
+++ b/web/src/SAP/src/controllers/NearestNeighborsController.py
@@ -38,11 +38,16 @@ def post(user, token, body: NearestNeighborsRequest):
 
         while status == "init":
             time.sleep(2)
-            api_response = api_instance.nn_result_v1_nearest_neighbors_nn_id_get(job_id)
+            # Only request basic info about the job when polling (don't ask for result)
+            api_response = api_instance.nn_result_v1_nearest_neighbors_nn_id_get(job_id, level='basic')
             status = api_response.status
 
         if status == "error":
             return jsonify({"status": "error"})
+
+        if status == "completed":
+            # Get the result
+            api_response = api_instance.nn_result_v1_nearest_neighbors_nn_id_get(job_id, level='full')
 
         response_dict = api_response.to_dict()
 


### PR DESCRIPTION
With the current (1.0) release of BioAPI you have to distinguish clearly between getting a job status and getting the full result of a finished job. This is controlled by the "level" parameter. The default is "full" which means "get the result". If the result is not ready, Bio API will unfortunately crash. With the current SOFI code, BioAPI will therefor crash with all calculation jobs that runs for more than 2 seconds.

Please test this change thoroughly in a SOFI dev instance with BioAPI jobs running for **more that two seconds** an inform me if it actually solves the problem.