### PR TITLE
feat: add project privacy handling to analysis page

### DIFF
--- a/bifrost/bifrost_queue_broker/common/database.py
+++ b/bifrost/bifrost_queue_broker/common/database.py
@@ -29,6 +29,7 @@ TBR_METADATA_COL_NAME = "sap_tbr_metadata"
 LIMS_METADATA_COL_NAME = "sap_lims_metadata"
 SAMPLES_COL_NAME = "samples"
 WORKSPACES_COL_NAME = "workspaces"
+PROJECT_PRIVACY_COL_NAME = "sap_project_privacy"
 
 SOFI_BIFROST_ENCRYPTION_NAMESPACE = os.environ.get(
     "SOFI_BIFROST_ENCRYPTION_NAME", "encryption.sap_pii"

--- a/web/src/SAP/common/database.py
+++ b/web/src/SAP/common/database.py
@@ -29,6 +29,7 @@ TBR_METADATA_COL_NAME = "sap_tbr_metadata"
 LIMS_METADATA_COL_NAME = "sap_lims_metadata"
 SAMPLES_COL_NAME = "samples"
 WORKSPACES_COL_NAME = "workspaces"
+PROJECT_PRIVACY_COL_NAME = "sap_project_privacy"
 
 SOFI_BIFROST_ENCRYPTION_NAMESPACE = os.environ.get(
     "SOFI_BIFROST_ENCRYPTION_NAME", "encryption.sap_pii"

--- a/web/src/SAP/src/controllers/AnalysisController.py
+++ b/web/src/SAP/src/controllers/AnalysisController.py
@@ -83,18 +83,13 @@ def get_sequence_by_id(user, token_info, sequence_id):
     return jsonify(row)
 
 def get_analysis_history(user, token_info, isolate_id):
-    institution_filter = (
-        token_info["institution"]
-        if token_info["sofi-data-clearance"] == "own-institution"
-        else False
-    )
-
     items = get_analysis_page(
         {"isolate_id": isolate_id},
         1000,
         0,
         authorized_columns(token_info),
-        institution_filter,
+        token_info["institution"],
+        token_info["sofi-data-clearance"],
         False,
     )
     response = {
@@ -107,20 +102,16 @@ def get_analysis(user, token_info, paging_token, page_size):
     assert_user_has("search", token_info)
     default_token = {"page_size": page_size or 100, "offset": 0}
     token = parse_paging_token(paging_token) or default_token
-    # If user has 'own-institution' clearance, pass an implicit filter to the query
-    institution_filter = (
-        token_info["institution"]
-        if token_info["sofi-data-clearance"] == "own-institution"
-        else False
-    )
+    
     items = get_analysis_page(
         token.get("query", {}),
         token["page_size"],
         token["offset"],
         authorized_columns(token_info),
-        institution_filter,
+        token_info["institution"],
+        token_info["sofi-data-clearance"]
     )
-    count = get_analysis_count(token.get("query", {}))
+    count = get_analysis_count(token.get("query", {}), token_info["institution"], token_info["sofi-data-clearance"])
     new_token = (
         None
         if len(items) < token["page_size"]
@@ -166,19 +157,14 @@ def search_analysis(user, token_info, query: AnalysisQuery):
 
     token = parse_paging_token(query.paging_token) or default_token
     print(default_token["query"], file=sys.stderr)
-    # If user has 'own-institution' clearance, pass an implicit filter to the query
-    institution_filter = (
-        token_info["institution"]
-        if token_info["sofi-data-clearance"] == "own-institution"
-        else False
-    )
 
     items = get_analysis_page(
         token["query"],
         token["page_size"],
         token["offset"],
         authorized_columns(token_info),
-        institution_filter,
+        token_info["institution"],
+        token_info["sofi-data-clearance"],
     )
 
     count = get_analysis_count(token["query"])


### PR DESCRIPTION
add project privacy logic.
Analysis samples can have a "project_id" column, a new table "sap_project_privacy" needs to be present in MongoDB, where records can have information about private projects. Example:
{ "project_id": 2, "institution": "SSI"}