### PR TITLE
fix: pin version of jsonschema to avoid breaking changes in newer ver…

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -27,3 +27,4 @@ python-keycloak==4.6.2
 httpx==0.27.2
 flask-cors
 flask
+jsonschema==3.2.0


### PR DESCRIPTION
pin version of jsonschema to avoid breaking changes in newer version. 
a recent update of another dependency removed a pin of jsonschema causing it to be updated to a version that the remaining dependencies didn't support. 
this pins it to a supported version