### PR TITLE
fix: use .value when comparing enums

### DIFF
--- a/web/src/SAP/src/controllers/ApprovalController.py
+++ b/web/src/SAP/src/controllers/ApprovalController.py
@@ -70,7 +70,7 @@ def create_approval(user, token_info, body: ApprovalRequest):
             time_fields.append("date_epi")
         for f in time_fields:
             seq_update[f] = appr.timestamp
-            appr.matrix[seq][f] = ApprovalStatus.APPROVED
+            appr.matrix[seq][f] = ApprovalStatus.APPROVED.value
         analysis_timestamp_updates[seq] = seq_update
 
     update_analysis(analysis_timestamp_updates)

--- a/web/src/SAP/src/repositories/queue.py
+++ b/web/src/SAP/src/repositories/queue.py
@@ -32,11 +32,11 @@ def await_update_loop(object_id):
     conn = get_connection()
     mydb = conn[DB_NAME]
     queue = mydb[QUEUE_COL_NAME]
-    result = {"status": ProcessingStatus.WAITING}
-    waiting_statuses = [ProcessingStatus.WAITING, ProcessingStatus.PROCESSING]
-    while max_tries != 0 or result and (result["status"] in waiting_statuses):
+    result = {"status": ProcessingStatus.WAITING.value}
+    waiting_statuses = [ProcessingStatus.WAITING.value, ProcessingStatus.PROCESSING.value]
+    while max_tries > 0 and (not result or (result["status"] in waiting_statuses)):
         result = queue.find_one({"_id": object_id})
         time.sleep(0.4)
         max_tries -= 1
 
-    return result["status"]
+    return result["status"] if result else ProcessingStatus.ERROR.value

--- a/web/src/SAP/src/services/queue_service.py
+++ b/web/src/SAP/src/services/queue_service.py
@@ -42,7 +42,7 @@ def post_and_await_approval(sequence_id, field_mask, user_institution, required_
     fields = {
         col: data.get(col, None)
         for col, val in field_mask.items()
-        if val == ApprovalStatus.APPROVED and col not in internal_fields
+        if val == ApprovalStatus.APPROVED.value and col not in internal_fields
     }
 
     institution = data.get("institution", user_institution)


### PR DESCRIPTION
fix enum usage in python code, since the db holds int values
also fix loop in await_update_loop so we exit when we find a result, instead of always using all 20 tries