### PR TITLE
Fix: check if debug mode exists

### DIFF
--- a/web/src/SAP/src/controllers/ApprovalController.py
+++ b/web/src/SAP/src/controllers/ApprovalController.py
@@ -106,7 +106,7 @@ def create_approval(user, token_info, body: ApprovalRequest):
 def handle_approvals(approvals: Approval, institution: str):
 
     # Post_and_await_approval always fails when testing on local machine. Disable in debug mode or approvals have no sequences
-    if os.environ["DEBUG_MODE"] == "1":
+    if "DEBUG_MODE" in os.environ and  os.environ["DEBUG_MODE"] == "1":
         return []
 
     errors = []


### PR DESCRIPTION
Når "DEBUG_MODE" ikke eksisterer i env vil approvals fejle. Oops.

Denne PR fikser problemet.