### PR TITLE
Cached analysis collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ Change the "Access token lifespan" to something more reasonable than 1 min, eg. 
 
 Consult `docs/`.
 
+## Migrations
+The migrations work by dynamically loading all the functions in the migrations.py file. Then it compares these function names to the ones in the migrations collection in the database. All migration functions whoose names are not in the migrations collection are executed, and after they are executed they are added to the collection. This way all migrations are executed exactly once on each database.
+
+All migrations are written in the `web/src/SAP/common/migrations.py` file.
+
 
 # Troubleshooting possible development errors
 ## Environment overview

--- a/app/src/app/analysis/workspace-menu.tsx
+++ b/app/src/app/analysis/workspace-menu.tsx
@@ -133,7 +133,7 @@ export const WorkspaceMenu = (props: WorkspaceMenuProps) => {
   return (
     <Menu>
       <MenuButton
-        style={{ minWidth: "8rem" }}
+        style={{ minWidth: Math.max(Math.floor((workspace?.name.length || 0) * 0.8),8) + "rem"}}
         marginX={2}
         paddingX={2}
         as={Button}

--- a/web/src/SAP/common/__init__.py
+++ b/web/src/SAP/common/__init__.py
@@ -1,0 +1,34 @@
+import sys
+import inspect
+import web.src.SAP.common.migrations as migrations
+from web.src.SAP.common.database import MIGRATIONS_COL_NAME,DB_NAME, get_connection
+
+conn = get_connection()
+mydb = conn[DB_NAME]
+migrations_coll = mydb[MIGRATIONS_COL_NAME]
+
+already_executed = list(map(lambda x: x["name"], migrations_coll.find()))
+
+
+migration_funcs = [
+    func for name, func in inspect.getmembers(migrations, inspect.isfunction)
+    if func.__module__ == migrations.__name__  # only functions defined there
+]
+
+print(already_executed,file=sys.stderr)
+
+# Example: conditionally execute
+for func in migration_funcs:
+    name = func.__name__ 
+
+    if name in already_executed:
+        print("Skipping migration:",name,file=sys.stderr)
+    else:
+        print("Executing:",name,file=sys.stderr)
+        try:
+            func()
+        except Exception:
+            print("Migration",name,"failed with error:",sys.exception(),"Stopping all migration until this is fixed!",file=sys.stderr)
+            break
+        migrations_coll.insert({"name": name})
+        

--- a/web/src/SAP/common/__init__.py
+++ b/web/src/SAP/common/__init__.py
@@ -15,8 +15,6 @@ migration_funcs = [
     if func.__module__ == migrations.__name__  # only functions defined there
 ]
 
-print(already_executed,file=sys.stderr)
-
 # Example: conditionally execute
 for func in migration_funcs:
     name = func.__name__ 
@@ -24,7 +22,7 @@ for func in migration_funcs:
     if name in already_executed:
         print("Skipping migration:",name,file=sys.stderr)
     else:
-        print("Executing:",name,file=sys.stderr)
+        print("Executing migration:",name,file=sys.stderr)
         try:
             func()
         except Exception:

--- a/web/src/SAP/common/__init__.py
+++ b/web/src/SAP/common/__init__.py
@@ -8,7 +8,7 @@ mydb = conn[DB_NAME]
 migrations_coll = mydb[MIGRATIONS_COL_NAME]
 
 
-# The migrations work my dynamically loading all the functions in the migrations.py file. Then it compares these function names to the ones in the migrations collection
+# The migrations work by dynamically loading all the functions in the migrations.py file. Then it compares these function names to the ones in the migrations collection
 #  in the database. All migration functions whoose names are not in the migrations collection are executed, and after they are executed they are added to the collection.
 #  This way all migrations are executed exactly once on each database.
 

--- a/web/src/SAP/common/__init__.py
+++ b/web/src/SAP/common/__init__.py
@@ -7,15 +7,18 @@ conn = get_connection()
 mydb = conn[DB_NAME]
 migrations_coll = mydb[MIGRATIONS_COL_NAME]
 
-already_executed = list(map(lambda x: x["name"], migrations_coll.find()))
 
+# The migrations work my dynamically loading all the functions in the migrations.py file. Then it compares these function names to the ones in the migrations collection
+#  in the database. All migration functions whoose names are not in the migrations collection are executed, and after they are executed they are added to the collection.
+#  This way all migrations are executed exactly once on each database.
+
+already_executed = list(map(lambda x: x["name"], migrations_coll.find()))
 
 migration_funcs = [
     func for name, func in inspect.getmembers(migrations, inspect.isfunction)
     if func.__module__ == migrations.__name__  # only functions defined there
 ]
 
-# Example: conditionally execute
 for func in migration_funcs:
     name = func.__name__ 
 

--- a/web/src/SAP/common/database.py
+++ b/web/src/SAP/common/database.py
@@ -31,6 +31,7 @@ SAMPLES_COL_NAME = "samples"
 WORKSPACES_COL_NAME = "workspaces"
 PROJECT_PRIVACY_COL_NAME = "sap_project_privacy"
 MIGRATIONS_COL_NAME = "migrations"
+ANALYSIS_CACHE_COL_NAME = "analysis_cache"
 
 SOFI_BIFROST_ENCRYPTION_NAMESPACE = os.environ.get(
     "SOFI_BIFROST_ENCRYPTION_NAME", "encryption.sap_pii"

--- a/web/src/SAP/common/database.py
+++ b/web/src/SAP/common/database.py
@@ -30,6 +30,7 @@ LIMS_METADATA_COL_NAME = "sap_lims_metadata"
 SAMPLES_COL_NAME = "samples"
 WORKSPACES_COL_NAME = "workspaces"
 PROJECT_PRIVACY_COL_NAME = "sap_project_privacy"
+MIGRATIONS_COL_NAME = "migrations"
 
 SOFI_BIFROST_ENCRYPTION_NAMESPACE = os.environ.get(
     "SOFI_BIFROST_ENCRYPTION_NAME", "encryption.sap_pii"

--- a/web/src/SAP/common/migrations.py
+++ b/web/src/SAP/common/migrations.py
@@ -1,0 +1,16 @@
+from web.src.SAP.common.database import MIGRATIONS_COL_NAME,DB_NAME,ANALYSIS_COL_NAME, get_connection
+import pymongo
+
+def create_migrations_collection():
+
+    conn = get_connection()
+    mydb = conn[DB_NAME]
+    if MIGRATIONS_COL_NAME not in mydb.collection_names():
+        mydb.create_collection(MIGRATIONS_COL_NAME)
+
+
+def create_analysis_sequence_index():
+    conn = get_connection()
+    db = conn[DB_NAME]
+    analysis_coll = db[ANALYSIS_COL_NAME]
+    analysis_coll.create_index([("timestamp",  pymongo.DESCENDING), ("sequence_ids",  pymongo.DESCENDING)])

--- a/web/src/SAP/src/repositories/analysis.py
+++ b/web/src/SAP/src/repositories/analysis.py
@@ -232,6 +232,7 @@ def get_analysis_page_bundle(
             }
         }
     ]
+    print(pipeline,file=sys.stderr)
     res = list(analysis.aggregate(pipeline))[0]
 
     count = res["count"][0]["count"] if res["count"] else 0

--- a/web/src/SAP/src/repositories/analysis.py
+++ b/web/src/SAP/src/repositories/analysis.py
@@ -232,8 +232,6 @@ def get_analysis_page_bundle(
             }
         }
     ]
-    print(pipeline,file=sys.stderr)
-
     res = list(analysis.aggregate(pipeline))[0]
 
     count = res["count"][0]["count"] if res["count"] else 0

--- a/web/src/SAP/src/repositories/analysis.py
+++ b/web/src/SAP/src/repositories/analysis.py
@@ -194,6 +194,14 @@ def get_analysis_page_bundle(
             }
         },
         {"$project": {"approval_info": 0}},
+        {
+            "$match": {
+                "$or": [
+                    {"_id": {"$in": workspace_items}},
+                    {"_id": {"$in": list(map(lambda id: ObjectId(id), workspace_items))}}
+                ]
+            }
+        } if workspace_items else None,
         {"$match": q} if q else None,
         {"$sort": {"_id": pymongo.DESCENDING}},
         {
@@ -201,12 +209,7 @@ def get_analysis_page_bundle(
         }
         if unique_sequences
         else None,
-        {"$replaceRoot": {"newRoot": "$record"}} if unique_sequences else None,
-        {
-            "$match": {"_id": {"$in": workspace_items}}
-        }
-        if workspace_items
-        else None,
+        {"$replaceRoot": {"newRoot": "$record"}} if unique_sequences else None
     ]
 
     base_pipeline = list(filter(lambda x: x is not None, base_pipeline))

--- a/web/src/SAP/src/repositories/analysis.py
+++ b/web/src/SAP/src/repositories/analysis.py
@@ -167,6 +167,14 @@ def get_analysis_page_bundle(
             }
         },
         {"$project": {"approval_info": 0}},
+        {
+            "$match": {
+                "$or": [
+                    {"_id": {"$in": workspace_items}},
+                    {"_id": {"$in": list(map(lambda id: ObjectId(id), workspace_items))}}
+                ]
+            }
+        } if workspace_items else None,
         {"$match": q} if q else None,
         {"$sort": {"_id": pymongo.DESCENDING}},
         {
@@ -174,12 +182,7 @@ def get_analysis_page_bundle(
         }
         if unique_sequences
         else None,
-        {"$replaceRoot": {"newRoot": "$record"}} if unique_sequences else None,
-        {
-            "$match": {"_id": {"$in": workspace_items}}
-        }
-        if workspace_items
-        else None,
+        {"$replaceRoot": {"newRoot": "$record"}} if unique_sequences else None
     ]
 
     base_pipeline = list(filter(lambda x: x is not None, base_pipeline))

--- a/web/src/SAP/src/repositories/analysis.py
+++ b/web/src/SAP/src/repositories/analysis.py
@@ -144,26 +144,53 @@ def get_analysis_page_bundle(
         {
             "$lookup": {
                 "from": "sap_approvals",
-                "let": {"seqId": "$sequence_id"},
+                "localField": "sequence_id",
+                "foreignField": "sequence_ids",
                 "pipeline": [
-                    {"$match": {"status": "submitted"}},
-                    {"$sort": {"timestamp": -1}},
-                    {"$project": {"status": 1, "matrixKeys": {"$objectToArray": "$matrix"}}},
-                    {"$unwind": "$matrixKeys"},
-                    {"$match": {"$expr": {"$eq": ["$matrixKeys.k", "$$seqId"]}}},
-                    {"$limit": 1},
+                    { "$match": { "status": "submitted" } },
+                    { "$sort": { "timestamp": -1 } },
+                    { "$limit": 1 }
                 ],
-                "as": "approval_info",
+                "as": "approval_info"
+            }
+        },
+        {
+            "$set": {
+                "approval_info": { "$first": "$approval_info" }
+            }
+        },
+        {
+            "$set": {
+                "matched_matrix_entry": {
+                    "$first": {
+                        "$map": {
+                            "input": {
+                            "$filter": {
+                                "input": {
+                                    "$objectToArray":
+                                        "$approval_info.matrix"
+                                    },
+                                    "as": "m",
+                                    "cond": {
+                                    "$eq": ["$$m.k", "$sequence_id"]
+                                }
+                            }
+                            },
+                            "as": "m",
+                            "in": "$$m.v"
+                        }
+                    }
+                }
             }
         },
         {
             "$addFields": {
-                "approval_status": {
-                    "$ifNull": [
-                        {"$arrayElemAt": ["$approval_info.matrixKeys.v.sequence_id", 0]},
-                        "pending",
-                    ]
-                }
+            "approval_status": {
+                "$ifNull": [
+                    "$matched_matrix_entry.sequence_id",
+                    "pending"
+                ]
+            }
             }
         },
         {"$project": {"approval_info": 0}},
@@ -205,6 +232,7 @@ def get_analysis_page_bundle(
             }
         }
     ]
+    print(pipeline,file=sys.stderr)
 
     res = list(analysis.aggregate(pipeline))[0]
 

--- a/web/src/SAP/src/repositories/analysis.py
+++ b/web/src/SAP/src/repositories/analysis.py
@@ -167,14 +167,6 @@ def get_analysis_page_bundle(
             }
         },
         {"$project": {"approval_info": 0}},
-        {
-            "$match": {
-                "$or": [
-                    {"_id": {"$in": workspace_items}},
-                    {"_id": {"$in": list(map(lambda id: ObjectId(id), workspace_items))}}
-                ]
-            }
-        } if workspace_items else None,
         {"$match": q} if q else None,
         {"$sort": {"_id": pymongo.DESCENDING}},
         {
@@ -182,7 +174,12 @@ def get_analysis_page_bundle(
         }
         if unique_sequences
         else None,
-        {"$replaceRoot": {"newRoot": "$record"}} if unique_sequences else None
+        {"$replaceRoot": {"newRoot": "$record"}} if unique_sequences else None,
+        {
+            "$match": {"_id": {"$in": workspace_items}}
+        }
+        if workspace_items
+        else None,
     ]
 
     base_pipeline = list(filter(lambda x: x is not None, base_pipeline))

--- a/web/src/SAP/src/repositories/analysis.py
+++ b/web/src/SAP/src/repositories/analysis.py
@@ -6,6 +6,7 @@ import flask
 import pymongo
 import logging
 import json
+from datetime import datetime, timedelta
 from web.src.SAP.generated.models import AnalysisResult
 from ...common.config.column_config import pii_columns
 from ...common.database import (
@@ -16,6 +17,7 @@ from ...common.database import (
     encrypt_dict,
     DB_NAME,
     ANALYSIS_COL_NAME,
+    ANALYSIS_CACHE_COL_NAME,
     PROJECT_PRIVACY_COL_NAME,
 )
 import sys
@@ -24,6 +26,83 @@ from bson.objectid import ObjectId
 def remove_id(item):
     item.pop("_id", None)
     return item
+
+
+
+
+last_updated_timestamp = None
+CACHE_TTL = timedelta(minutes=5)
+
+def invalidate_analysis_cache():
+    global last_updated_timestamp
+    last_updated_timestamp = None
+
+def ensure_cache_updated():
+    global last_updated_timestamp
+
+    now = datetime.utcnow()
+
+    # Case 1: never updated or invalidated
+    if last_updated_timestamp is None:
+        update_analysis_cache()
+        last_updated_timestamp = now
+        return
+
+    # Case 2: expired
+    if now - last_updated_timestamp > CACHE_TTL:
+        update_analysis_cache()
+        last_updated_timestamp = now
+
+def update_analysis_cache():
+    print("Updating analysis cache",file=sys.stderr)
+    conn, encryption_client = get_connection(with_enc=True)
+    mydb = conn[DB_NAME]
+    analysis = mydb[ANALYSIS_COL_NAME]
+
+    pipeline = [
+        {
+            "$lookup": {
+                "from": TBR_METADATA_COL_NAME,
+                "localField": "isolate_id",
+                "foreignField": "isolate_id",
+                "as": "metadata",
+            }
+        },
+        {
+            "$replaceRoot": {
+                "newRoot": {"$mergeObjects": [{"$arrayElemAt": ["$metadata", 0]}, "$$ROOT"]}
+            }
+        },
+        {
+            "$lookup": {
+                "from": LIMS_METADATA_COL_NAME,
+                "localField": "isolate_id",
+                "foreignField": "isolate_id",
+                "as": "metadata",
+            }
+        },
+        {
+            "$replaceRoot": {
+                "newRoot": {"$mergeObjects": [{"$arrayElemAt": ["$metadata", 0]}, "$$ROOT"]}
+            }
+        },
+        {
+            "$lookup": {
+                "from": MANUAL_METADATA_COL_NAME,
+                "localField": "isolate_id",
+                "foreignField": "isolate_id",
+                "as": "metadata",
+            }
+        },
+        {
+            "$replaceRoot": {
+                "newRoot": {"$mergeObjects": [{"$arrayElemAt": ["$metadata", 0]}, "$$ROOT"]}
+            }
+        },
+        {"$out": ANALYSIS_CACHE_COL_NAME}
+    ]
+
+    analysis.aggregate(pipeline)
 
 def get_analysis_page_bundle(
     query,
@@ -36,9 +115,12 @@ def get_analysis_page_bundle(
     sorting=None,
     workspace_items: Optional[List[str]] = None,
 ):
+
+    ensure_cache_updated()
+
     conn, encryption_client = get_connection(with_enc=True)
     mydb = conn[DB_NAME]
-    analysis = mydb[ANALYSIS_COL_NAME]
+    analysis_cache = mydb[ANALYSIS_CACHE_COL_NAME]
 
     q = encrypt_dict(encryption_client, query or {}, pii_columns())
 
@@ -80,47 +162,6 @@ def get_analysis_page_bundle(
         distinct_group[field] = {"$addToSet": f"${field}"}
 
     base_pipeline = [
-        {
-            "$lookup": {
-                "from": TBR_METADATA_COL_NAME,
-                "localField": "isolate_id",
-                "foreignField": "isolate_id",
-                "as": "metadata",
-            }
-        },
-        # This removes isolates without metadata.
-        # {"$match": {"metadata": {"$ne": []}}},
-        {
-            "$replaceRoot": {
-                "newRoot": {"$mergeObjects": [{"$arrayElemAt": ["$metadata", 0]}, "$$ROOT"]}
-            }
-        },
-        {
-            "$lookup": {
-                "from": LIMS_METADATA_COL_NAME,
-                "localField": "isolate_id",
-                "foreignField": "isolate_id",
-                "as": "metadata",
-            }
-        },
-        {
-            "$replaceRoot": {
-                "newRoot": {"$mergeObjects": [{"$arrayElemAt": ["$metadata", 0]}, "$$ROOT"]}
-            }
-        },
-        {
-            "$lookup": {
-                "from": MANUAL_METADATA_COL_NAME,
-                "localField": "isolate_id",
-                "foreignField": "isolate_id",
-                "as": "metadata",
-            }
-        },
-        {
-            "$replaceRoot": {
-                "newRoot": {"$mergeObjects": [{"$arrayElemAt": ["$metadata", 0]}, "$$ROOT"]}
-            }
-        },
         {
             "$lookup": {
                 "from": PROJECT_PRIVACY_COL_NAME,
@@ -235,8 +276,7 @@ def get_analysis_page_bundle(
             }
         }
     ]
-    print(pipeline,file=sys.stderr)
-    res = list(analysis.aggregate(pipeline))[0]
+    res = list(analysis_cache.aggregate(pipeline))[0]
 
     count = res["count"][0]["count"] if res["count"] else 0
     md = res["filter_op"][0] if res["filter_op"] else {}
@@ -277,6 +317,8 @@ def update_analysis(change):
             if field_name != "id":
                 update_data[f"userchanged_{field_name}"] = True
         analysis.update_one({"sequence_id": update_data["id"]}, {"$set": update_data})
+    
+    invalidate_analysis_cache()
 
 
 def get_single_analysis(id: str) -> Dict[str, Any]:

--- a/web/src/SAP/src/repositories/metadata.py
+++ b/web/src/SAP/src/repositories/metadata.py
@@ -5,6 +5,7 @@ import logging
 import json
 from web.src.SAP.generated.models import BaseMetadata, Organization
 from web.src.SAP.generated.models.upload_metadata_fields import UploadMetadataFields
+from web.src.SAP.src.repositories.analysis import invalidate_analysis_cache
 from ...common.database import (
     ANALYSIS_COL_NAME,
     get_connection,
@@ -37,6 +38,7 @@ def upsert_analysis_result_for_upload(
         },
         upsert=True,
     )
+    invalidate_analysis_cache()
 
 
 def upsert_manual_metadata(metadata: UploadMetadataFields):


### PR DESCRIPTION
Tilføjer en analysis_cache collection, som indeholder det første trin af fetch pipelinen. Denne cache blive kørt af en query hvis cachen er mere end 5 min gammel ELLER ved er blevet invalidated af at et felt er blevet opdataret.

Jeg tænker den ikke behøver være en del af det nuværende feature-freeze da det lige skal godt gennemtestes før det ryger i prod. Desuden bliver cachen ikke invalideret af aggregation pipline. Jeg mener jeg har fundet alle andre steder hvor felterne kan blive opdateret, men kan ikke 100% garanteret det.