### PR TITLE
Hotfix 2026 04 09

### DIFF
--- a/app/src/app/analysis/data-table/data-table-column-header.tsx
+++ b/app/src/app/analysis/data-table/data-table-column-header.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @compiled/react */
-import React from "react";
+import React, { useReducer } from "react";
 import { Column, ColumnInstance } from "react-table";
 import "@compiled/react";
 import { Tooltip } from "@chakra-ui/react";
@@ -36,6 +36,7 @@ function DataTableColumnHeader<T extends NotEmpty>(
   } = props;
 
   const noop = React.useCallback(() => {}, []);
+  const [renderTrigger, forceRerender] = useReducer(o => !o,true);
 
   const doResize = React.useCallback(() => {
     onResize(columnIndex);
@@ -72,10 +73,16 @@ function DataTableColumnHeader<T extends NotEmpty>(
         {canSelectColumn(column.id) && (
           <SelectionCheckBox
             onClick={(e) => {
-              onSelectColumn(column);
+              try {
+                onSelectColumn(column);
+              } catch (err) {
+                alert((err as Error).message)
+                forceRerender();
+              }
               e.stopPropagation();
             }}
             css={headerButton}
+            renderTrigger={renderTrigger}
             {...calcColSelectionState(column)}
           />
         )}

--- a/app/src/app/analysis/data-table/data-table.tsx
+++ b/app/src/app/analysis/data-table/data-table.tsx
@@ -477,6 +477,7 @@ function DataTable<T extends NotEmpty>(props: DataTableProps<T>) {
       onColumnResize,
       selection,
       selectAll,
+      totalCount,
     ]
   );
 

--- a/app/src/app/analysis/data-table/data-table.tsx
+++ b/app/src/app/analysis/data-table/data-table.tsx
@@ -415,6 +415,10 @@ function DataTable<T extends NotEmpty>(props: DataTableProps<T>) {
     [dataGridRef]
   );
 
+  const totalCount = useSelector<RootState>((s) =>
+      s.entities.analysisTotalCount
+    ) as number;
+
   const onSelectColumn = React.useCallback(
     (col: Column<T>) => {
       const { checked, indeterminate } = calcColSelectionState(col);
@@ -424,9 +428,15 @@ function DataTable<T extends NotEmpty>(props: DataTableProps<T>) {
         if (selection && Object.keys(selection).length > 0) {
         } else {
           // This immediately selectes all if the data is ready. We dont want to redo the select all with an empty
-          // selection
+          // selection. Furthermore, if it has counted more than 3000 rows we REFUSE to select all, since python
+          // bson will reject a > 16mb document. Perhaps we will fix the backend later, but you would never want
+          // to select more than 3000 rows...
+          if (totalCount > 3000) {
+            throw new Error("Cannot select more than 3000 rows.")
+          }
           selectAll();
           doIncSel = false;
+          
         }
       } else {
         const sel = rows

--- a/app/src/app/analysis/data-table/selection-check-box.tsx
+++ b/app/src/app/analysis/data-table/selection-check-box.tsx
@@ -14,12 +14,14 @@ type SelectionCheckBoxProps = DetailedHTMLProps<
   checked?: boolean;
   indeterminate?: boolean;
   visible?: boolean;
+  // Change this value to force a rerender
+  renderTrigger?: boolean;
   onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
 };
 
 const SelectionCheckBox = forwardRef(
   (
-    { indeterminate, checked, visible, ...rest }: SelectionCheckBoxProps,
+    { indeterminate, checked, visible, renderTrigger, ...rest }: SelectionCheckBoxProps,
     ref
   ) => {
     const defaultRef = React.useRef<HTMLInputElement>();
@@ -31,7 +33,7 @@ const SelectionCheckBox = forwardRef(
       resolvedRef.current.checked = checked;
       resolvedRef.current.style.visibility =
         visible !== false ? "visible" : "hidden";
-    }, [resolvedRef, indeterminate, checked, visible]);
+    }, [resolvedRef, indeterminate, checked, visible, renderTrigger]);
 
     return (
       <input

--- a/app/src/app/analysis/search/search-utils.ts
+++ b/app/src/app/analysis/search/search-utils.ts
@@ -239,20 +239,20 @@ export const displayOperandName = ({
     return `${field}=${term}`;
   } else if (term_max && term_min) {
     const minDate = Date.parse(term_min);
-    const minVal = isNaN(minDate) ? term_min : new Date(term_min).toLocaleDateString()
+    const minVal = (isNaN(minDate) || !isNaN(Number(term_min))) ? term_min : new Date(term_min).toLocaleDateString()
 
     const maxDate = Date.parse(term_max);
-    const maxVal = isNaN(maxDate) ? term_max : new Date(term_max).toLocaleDateString()
+    const maxVal = (isNaN(maxDate) || !isNaN(Number(term_max))) ? term_max : new Date(term_max).toLocaleDateString()
 
     return `${minVal} < ${field} < ${maxVal}`;
   } else if (term_max) {
     const maxDate = Date.parse(term_max);
-    const maxVal = isNaN(maxDate) ? term_max : new Date(term_max).toLocaleDateString()
+    const maxVal = (isNaN(maxDate) || !isNaN(Number(term_max))) ? term_max : new Date(term_max).toLocaleDateString()
 
     return `${field} < ${maxVal}`;
   } else if (term_min) {
     const minDate = Date.parse(term_min);
-    const minVal = isNaN(minDate) ? term_min : new Date(term_min).toLocaleDateString()
+    const minVal = (isNaN(minDate) || !isNaN(Number(term_min))) ? term_min : new Date(term_min).toLocaleDateString()
 
     return `${field} > ${minVal}`;
   }

--- a/web/src/SAP/src/repositories/analysis.py
+++ b/web/src/SAP/src/repositories/analysis.py
@@ -235,7 +235,6 @@ def get_analysis_page_bundle(
             }
         }
     ]
-    print(pipeline,file=sys.stderr)
     res = list(analysis.aggregate(pipeline))[0]
 
     count = res["count"][0]["count"] if res["count"] else 0

--- a/web/src/SAP/src/services/search/transpiler.py
+++ b/web/src/SAP/src/services/search/transpiler.py
@@ -87,16 +87,22 @@ def structure_range_or_wildcard(field, node):
         coerced_min = coerce_term(node.term_min)
         coerced_max = coerce_term(node.term_max)
 
-        if not ((coerced_max is None or isinstance(coerced_max,datetime)) and (coerced_min is None or isinstance(coerced_min,datetime))):
-            # If either value is not a date. It is likely a ID based range search.
+        if ((coerced_max is None or isinstance(coerced_max,str)) and (coerced_min is None or isinstance(coerced_min,str))):
+            # Both values are strings. It is an id range search
             return id_range_search(field,str(coerced_min),str(coerced_max)), True
+        
+        if coerced_max is not None and isinstance(coerced_max, datetime):
+            coerced_max = coerced_max.isoformat()
+
+        if coerced_min is not None and isinstance(coerced_min, datetime):
+            coerced_min = coerced_min.isoformat()
 
         if coerced_max is None:
-            return {"$gte": coerced_min.isoformat()}, False
+            return {"$gte": coerced_min}, False
         if coerced_min is None:
-            return {"$lte": coerced_max.isoformat()}, False
+            return {"$lte": coerced_max}, False
 
-        return {"$gte": coerced_min.isoformat(), "$lte": coerced_max.isoformat()}, False
+        return {"$gte": coerced_min, "$lte": coerced_max}, False
     raise ValueError("Invalid query. Leaf missing field or term.")
 
 def structure_leaf(node, is_negated):


### PR DESCRIPTION
Denne PR skal enligt ikke merges. Den er bare så man kan se præcis hvilke ændringer der er på hotfixet til det seneste release.

Fikser at range searches på integers er gået i stykker, og at den nu forbyder "select all" på mere end 3000 rækker.