### PR TITLE
Nearest neighbor fix

### DIFF
--- a/app/src/app/analysis/analysis-page.tsx
+++ b/app/src/app/analysis/analysis-page.tsx
@@ -87,6 +87,7 @@ import {
 import { WorkspaceMenu } from "./workspace-menu";
 import { useInView } from "react-intersection-observer";
 import { RenderCellControl } from "./data-table/renderCellControl";
+import { UseApprovableColumns } from "./analysis-utils";
 
 // When the fields in this array are 'approved', a given sequence is rendered
 // as 'approved' also.
@@ -311,23 +312,7 @@ export default function AnalysisPage() {
     [columnConfigs, t]
   );
 
-  const approvableColumns = React.useMemo(
-    () => [
-      ...new Set(
-        Object.values(columnConfigs || {})
-          .map((c) => c?.approves_with)
-          .reduce((a, b) => a.concat(b), [])
-          .concat(
-            Object.values(columnConfigs || {})
-              .filter((c) => c?.approvable)
-              .filter((c) => !c?.computed)
-              .map((c) => c?.field_name)
-          )
-          .filter((x) => x !== undefined)
-      ),
-    ],
-    [columnConfigs]
-  );
+  const approvableColumns = UseApprovableColumns();
 
   const selectionDataIntersection = useMemo(() => Object.keys(selection).filter(s => data.find(d => d.sequence_id === s)).length, [selection, data]);
 

--- a/app/src/app/analysis/analysis-page.tsx
+++ b/app/src/app/analysis/analysis-page.tsx
@@ -82,6 +82,7 @@ import {
   buildQueryFromFilters,
   checkExpressionEquality,
   checkSortEquality,
+  mergeExpressions,
   recurseSearchTree,
 } from "./search/search-utils";
 import { WorkspaceMenu } from "./workspace-menu";
@@ -609,10 +610,15 @@ export default function AnalysisPage() {
 
       const forceUpdate = (inView && !prevInViewRef.current.inView) || loadAllRef.current.needsFetch;
       loadAllRef.current.needsFetch = false;
+
+      const tempWsFilter = (workspace && workspace.id === "temp-workspace" && workspace.samples) ? workspace.samples.map(objectid => ({field: "_id",term: objectid} as QueryOperand)).reduce((a,b) => ({operator: QueryOperator.OR, left: a, right: b})) : null
+
+      const joinedExpression: QueryExpression = mergeExpressions(QueryOperator.AND,q.expression,tempWsFilter)
+
       const newExpression = q.clearAllFields
-        ? q.expression
+        ? joinedExpression
         : mergeFilters(
-          q.expression || {},
+          joinedExpression || {},
           propFilters,
           rangeFilters,
           approvalFilters

--- a/app/src/app/analysis/analysis-page.tsx
+++ b/app/src/app/analysis/analysis-page.tsx
@@ -169,7 +169,7 @@ export default function AnalysisPage() {
   }, [workspaces, workspace]);
 
   useEffect(() => {
-    if (switchWsWhenReady && workspace && workspace.id == "temp-workspace" && workspaceCreationState.status === 200) {
+    if (switchWsWhenReady && workspace && workspace.id === "temp-workspace" && workspaceCreationState.status === 200) {
       setWorkspace(workspaces[workspaces.length - 1]);
       setSwitchWsWhenReady(false);
     }
@@ -401,15 +401,6 @@ export default function AnalysisPage() {
 
     if (pageState.isNarrowed) {
       return selectionValues;
-    }
-
-    if (workspace) {
-      return [
-        ...selectionValues.filter(
-          (sv) => !workspace.samples!.find((sid) => sid == sv.id)
-        ),
-        ...data.filter((d) => workspace.samples!.find((s) => s === d.id)),
-      ];
     }
 
     return [
@@ -656,7 +647,7 @@ export default function AnalysisPage() {
       setLastSearchWs(workspace);
       appendToSearchHistory(newExpression);
 
-      const searchingWithWs = workspace && workspace.id != "temp-workspace";
+      const searchingWithWs = workspace && workspace.id !== "temp-workspace";
 
       if (
         newExpression &&

--- a/app/src/app/analysis/analysis-utils.ts
+++ b/app/src/app/analysis/analysis-utils.ts
@@ -1,0 +1,25 @@
+import { RootState } from "app/root-reducer";
+import { useSelector } from "react-redux";
+import { ColumnSlice } from "./analysis-query-configs";
+
+export const UseApprovableColumns = () => {
+
+    const columnConfigs = useSelector<RootState>(
+        (s) => s.entities.columns
+    ) as ColumnSlice;
+
+    return [
+        ...new Set(
+            Object.values(columnConfigs || {})
+                .map((c) => c?.approves_with)
+                .reduce((a, b) => a.concat(b), [])
+                .concat(
+                    Object.values(columnConfigs || {})
+                        .filter((c) => c?.approvable)
+                        .filter((c) => !c?.computed)
+                        .map((c) => c?.field_name)
+                )
+                .filter((x) => x !== undefined)
+        ),
+    ]
+}

--- a/app/src/app/analysis/nearest-neighbor/nearest-neighbor-modal.tsx
+++ b/app/src/app/analysis/nearest-neighbor/nearest-neighbor-modal.tsx
@@ -32,6 +32,7 @@ import { Checkbox } from "@chakra-ui/react";
 import { useMutation } from "redux-query-react";
 import { setSelection } from "../analysis-selection-configs";
 import { UseApprovableColumns } from "../analysis-utils";
+import { RootState } from "app/root-reducer";
 
 type Props = {
   selection: DataTableSelection<AnalysisResult>;
@@ -79,6 +80,9 @@ export const NearestNeighborModal = (props: Props) => {
     searchNearestNeighbors,
   ] = useMutation((req: NearestNeighborsRequest) => getNearestNeighbors(req));
 
+  const data = useSelector<RootState, AnalysisResult[]>((s) => Object.values((s.entities.analysis) ?? {}) as AnalysisResult[]);
+  
+
   const approvableColumns = UseApprovableColumns();
 
   useEffect(() => {
@@ -109,8 +113,13 @@ export const NearestNeighborModal = (props: Props) => {
         for (const reqId of ids) {
           const response = nearestNeighborsResponses[reqId];
           response.result?.forEach((neighbor) => {
+
+            // We response does not necesarrily contain everything we need. We instead need to find the correct locally saved
+            // version of the AnalysisResult. If it is not stored locally because of the current query, we fall back.
+            const neighbor_local = data.find(d => d.sequence_id === neighbor.sequence_id) || neighbor
+
             if (!selection[neighbor.sequence_id]) {
-              neighbors[neighbor.sequence_id] = neighbor;
+              neighbors[neighbor.sequence_id] = neighbor_local;
             }
           });
         }

--- a/app/src/app/analysis/nearest-neighbor/nearest-neighbor-modal.tsx
+++ b/app/src/app/analysis/nearest-neighbor/nearest-neighbor-modal.tsx
@@ -31,6 +31,7 @@ import {
 import { Checkbox } from "@chakra-ui/react";
 import { useMutation } from "redux-query-react";
 import { setSelection } from "../analysis-selection-configs";
+import { UseApprovableColumns } from "../analysis-utils";
 
 type Props = {
   selection: DataTableSelection<AnalysisResult>;
@@ -78,6 +79,8 @@ export const NearestNeighborModal = (props: Props) => {
     searchNearestNeighbors,
   ] = useMutation((req: NearestNeighborsRequest) => getNearestNeighbors(req));
 
+  const approvableColumns = UseApprovableColumns();
+
   useEffect(() => {
     // Collector
     if (!isSearching || isPending || !isFinished) {
@@ -117,9 +120,10 @@ export const NearestNeighborModal = (props: Props) => {
         );
         if (Object.values(neighbors).length) {
           const newSelection = Object.assign({}, selection);
+          const cells = Object.fromEntries(approvableColumns.map(c => [c, true]))
           Object.values(neighbors).forEach((n) => {
             newSelection[n.sequence_id] = {
-              cells: {},
+              cells,
               original: n,
             };
           });

--- a/app/src/app/analysis/nearest-neighbor/nearest-neighbor-modal.tsx
+++ b/app/src/app/analysis/nearest-neighbor/nearest-neighbor-modal.tsx
@@ -111,7 +111,7 @@ export const NearestNeighborModal = (props: Props) => {
           const response = nearestNeighborsResponses[reqId];
           response.result?.forEach((neighbor) => {
             if (!selection[neighbor.sequence_id]) {
-              neighbors[neighbor.sequence_id] = neighbor_local;
+              neighbors[neighbor.sequence_id] = neighbor;
             }
           });
         }

--- a/app/src/app/analysis/nearest-neighbor/nearest-neighbor-modal.tsx
+++ b/app/src/app/analysis/nearest-neighbor/nearest-neighbor-modal.tsx
@@ -32,7 +32,6 @@ import { Checkbox } from "@chakra-ui/react";
 import { useMutation } from "redux-query-react";
 import { setSelection } from "../analysis-selection-configs";
 import { UseApprovableColumns } from "../analysis-utils";
-import { RootState } from "app/root-reducer";
 
 type Props = {
   selection: DataTableSelection<AnalysisResult>;
@@ -80,8 +79,6 @@ export const NearestNeighborModal = (props: Props) => {
     searchNearestNeighbors,
   ] = useMutation((req: NearestNeighborsRequest) => getNearestNeighbors(req));
 
-  const data = useSelector<RootState, AnalysisResult[]>((s) => Object.values((s.entities.analysis) ?? {}) as AnalysisResult[]);
-  
 
   const approvableColumns = UseApprovableColumns();
 
@@ -113,11 +110,6 @@ export const NearestNeighborModal = (props: Props) => {
         for (const reqId of ids) {
           const response = nearestNeighborsResponses[reqId];
           response.result?.forEach((neighbor) => {
-
-            // We response does not necesarrily contain everything we need. We instead need to find the correct locally saved
-            // version of the AnalysisResult. If it is not stored locally because of the current query, we fall back.
-            const neighbor_local = data.find(d => d.sequence_id === neighbor.sequence_id) || neighbor
-
             if (!selection[neighbor.sequence_id]) {
               neighbors[neighbor.sequence_id] = neighbor_local;
             }

--- a/app/src/app/analysis/search/search-utils.ts
+++ b/app/src/app/analysis/search/search-utils.ts
@@ -315,6 +315,20 @@ export const checkExpressionEquality = (
   return true;
 };
 
+export const mergeExpressions = (operator: QueryOperator, left: QueryOperand |null, right: QueryOperand |null) => {
+  if (left && right && Object.keys(left).length && Object.keys(right).length) {
+    return {
+      operator,
+      left,
+      right
+    }
+  } else if (left && Object.keys(left).length) {
+    return left
+  } else {
+    return right
+  }
+}
+
 // Helper function to build query expression from filter state
 export const buildQueryFromFilters = (
   propFilters: { [field: string]: string[] },

--- a/web/src/SAP/src/controllers/NearestNeighborsController.py
+++ b/web/src/SAP/src/controllers/NearestNeighborsController.py
@@ -1,5 +1,6 @@
 import time
 from typing import cast
+import os
 
 from flask import abort
 from flask.json import jsonify
@@ -18,6 +19,14 @@ def post(user, token, body: NearestNeighborsRequest):
     assert_user_has("search", token)
     if body.id is None:
         return abort(400)
+    
+    if "DEBUG_MODE" in os.environ and  os.environ["DEBUG_MODE"] == "1":
+        return jsonify({"status": "completed",
+                        "jobId": "6bc4ae505783473e99a9b41fb5cdfa06", 
+                        "createdAt": "2026-04-15T08:10:08.7380000",
+                        "result": [
+                            get_analysis_with_metadata("2503W47426_N_WGS_910_SSI")
+                        ] })
     
     with ApiClient(Configuration(host="http://bioapi:8000")) as api_client:
         sample = get_single_sample(body.id)

--- a/web/src/SAP/src/controllers/NearestNeighborsController.py
+++ b/web/src/SAP/src/controllers/NearestNeighborsController.py
@@ -1,15 +1,18 @@
 import time
 from typing import cast
 import os
+from datetime import datetime
+from uuid import uuid4
+from random import randint
 
 from flask import abort
 from flask.json import jsonify
 from pydantic import StrictBool, StrictInt
 
 from web.src.SAP.generated.models.nearest_neighbors_request import NearestNeighborsRequest
-from web.src.SAP.src.repositories.analysis import get_analysis_with_metadata, get_single_analysis_by_object_id
+from web.src.SAP.src.repositories.analysis import get_analysis_page_bundle, get_analysis_with_metadata, get_single_analysis_by_object_id
 from web.src.SAP.src.repositories.samples import get_single_sample
-from web.src.SAP.src.security.permission_check import assert_user_has
+from web.src.SAP.src.security.permission_check import assert_user_has, authorized_columns
 from web.src.services.bio_api.openapi.api.nearest_neighbors_api import NearestNeighborsApi
 from web.src.services.bio_api.openapi.api_client import ApiClient
 from web.src.services.bio_api.openapi.configuration import Configuration
@@ -21,12 +24,7 @@ def post(user, token, body: NearestNeighborsRequest):
         return abort(400)
     
     if "DEBUG_MODE" in os.environ and  os.environ["DEBUG_MODE"] == "1":
-        return jsonify({"status": "completed",
-                        "jobId": "6bc4ae505783473e99a9b41fb5cdfa06", 
-                        "createdAt": "2026-04-15T08:10:08.7380000",
-                        "result": [
-                            get_analysis_with_metadata("2503W47426_N_WGS_910_SSI")
-                        ] })
+        return jsonify(mock_nearest_neighbors(token))
     
     with ApiClient(Configuration(host="http://bioapi:8000")) as api_client:
         sample = get_single_sample(body.id)
@@ -78,3 +76,17 @@ def post(user, token, body: NearestNeighborsRequest):
 
 def get(user, token, body:NearestNeighborsRequest):
     return post(user, token, body)
+
+def mock_nearest_neighbors(token):
+
+    page_size = randint(1,10)
+    offset = randint(0,500)
+
+    bundle = get_analysis_page_bundle({},page_size,offset,authorized_columns(token),None,"all")
+
+    return {
+        "status": "completed",
+        "jobId": str(uuid4()).replace("-",""), 
+        "createdAt": datetime.now().isoformat(),
+        "result": bundle["items"]
+    }


### PR DESCRIPTION
Fikser at man ikke kan se alle resultaterne fra en neighbors analyse når der oprettes et temp workspace.

Problemet var at temp workspaces før kun kunne vise rækker som er i den nuværende query, da den laver en frontend filtering på sequence_id. Dette virkede ikke på rækker som ikke er en del af den nuværende page. Ofte ville den selection som kommer fra en nearest neighbor ikke være en del af den nuværende page.

Det er blevet løst ved at lave temp-workspace filtering ved manipulering af querien.

Der er også nu mocking af nearest neighbor.