### PR TITLE
Move select all column

### DIFF
--- a/app/src/app/analysis/analysis-page.tsx
+++ b/app/src/app/analysis/analysis-page.tsx
@@ -721,9 +721,9 @@ export default function AnalysisPage() {
   );
 
   const canSelectColumn = React.useCallback(
-    (columnName: string) => {
+    (columnName: string, columnIndex: number) => {
       return (
-        (!pageState.isNarrowed && columnName === "sequence_id") ||
+        (!pageState.isNarrowed && columnIndex === 0) ||
         (pageState.isNarrowed &&
           columnConfigs[columnName]?.approvable &&
           !columnConfigs[columnName]?.computed)

--- a/app/src/app/analysis/data-table/data-table-column-header.tsx
+++ b/app/src/app/analysis/data-table/data-table-column-header.tsx
@@ -15,7 +15,7 @@ type DataTableColumnHeaderProps<T extends NotEmpty> = {
   calcColSelectionState: (
     column: Column<T>
   ) => { checked: boolean; indeterminate: boolean; visible?: boolean };
-  canSelectColumn: (column: string) => boolean;
+  canSelectColumn: (column: string, columnIndex: number) => boolean;
   onSelectColumn: (column: Column<T>) => void;
   onResize: (columnIndex: number) => void;
   onSort?: ({ column: string, ascending: boolean }) => void;
@@ -70,10 +70,11 @@ function DataTableColumnHeader<T extends NotEmpty>(
       onKeyDown={noop}
     >
       <div role="tab" css={columnStyle}>
-        {canSelectColumn(column.id) && (
+        {canSelectColumn(column.id, columnIndex) && (
           <SelectionCheckBox
             onClick={(e) => {
               try {
+                
                 onSelectColumn(column);
               } catch (err) {
                 alert((err as Error).message)

--- a/app/src/app/analysis/data-table/data-table.tsx
+++ b/app/src/app/analysis/data-table/data-table.tsx
@@ -51,7 +51,7 @@ type DataTableProps<T extends NotEmpty> = {
   setColumnSort?: (columnSort: { column: string; ascending: boolean }) => void;
   data: T[];
   primaryKey: keyof T;
-  canSelectColumn: (columnName: string) => boolean;
+  canSelectColumn: (columnName: string, columnIndex: number) => boolean;
   canApproveColumn: (columnName: string) => boolean;
   isJudgedCell: (rowId: string, columnName: string) => boolean;
   getDependentColumns: (columnName: keyof T) => Array<keyof T>;
@@ -358,7 +358,7 @@ function DataTable<T extends NotEmpty>(props: DataTableProps<T>) {
   const calcColSelectionState = React.useCallback(
     (col: Column<T>) => {
       const c = Object.values(selection).filter(
-        (x) => x.cells[col.id] === true
+        (x) => Object.values(x.cells).some(c => c)
       );
       if (c.length === 0) {
         return { checked: false, indeterminate: false };
@@ -424,7 +424,10 @@ function DataTable<T extends NotEmpty>(props: DataTableProps<T>) {
       const { checked, indeterminate } = calcColSelectionState(col);
       let incSel: DataTableSelection<T> = {};
       let doIncSel = true;
-      if (col.id === "sequence_id") {
+
+      // Unless reordered this will be sequence_id
+      const firstColumnsid = visibleColumnInstances.at(0)?.id;
+      if (col.id === firstColumnsid) {
         if (selection && Object.keys(selection).length > 0) {
         } else {
           // This immediately selectes all if the data is ready. We dont want to redo the select all with an empty

--- a/app/src/app/analysis/data-table/data-table.tsx
+++ b/app/src/app/analysis/data-table/data-table.tsx
@@ -358,7 +358,7 @@ function DataTable<T extends NotEmpty>(props: DataTableProps<T>) {
   const calcColSelectionState = React.useCallback(
     (col: Column<T>) => {
       const c = Object.values(selection).filter(
-        (x) => Object.values(x.cells).some(c => c)
+        (x) => Object.values(x.cells).some(cell => cell)
       );
       if (c.length === 0) {
         return { checked: false, indeterminate: false };
@@ -426,7 +426,7 @@ function DataTable<T extends NotEmpty>(props: DataTableProps<T>) {
       let doIncSel = true;
 
       // Unless reordered this will be sequence_id
-      const firstColumnsid = visibleColumnInstances.at(0)?.id;
+      const firstColumnsid = visibleColumnInstances.length > 0 ? visibleColumnInstances[0].id : null;
       if (col.id === firstColumnsid) {
         if (selection && Object.keys(selection).length > 0) {
         } else {
@@ -471,6 +471,7 @@ function DataTable<T extends NotEmpty>(props: DataTableProps<T>) {
       onColumnResize(0);
     },
     [
+      visibleColumnInstances,
       primaryKey,
       rows,
       calcColSelectionState,


### PR DESCRIPTION
Select all knappen er nu altid tilgængelig på den første kolonne header, uanset om man har reorderet eller gemt nogle kolonner.