### PR TITLE
Enforced proper dates

### DIFF
--- a/web/src/SAP/migrations.py
+++ b/web/src/SAP/migrations.py
@@ -1,3 +1,6 @@
+import sys
+
+from web.src.SAP.common.config.column_config import columns
 from web.src.SAP.common.database import MIGRATIONS_COL_NAME,DB_NAME,ANALYSIS_COL_NAME, get_connection
 import pymongo
 
@@ -14,3 +17,25 @@ def create_analysis_sequence_index():
     db = conn[DB_NAME]
     analysis_coll = db[ANALYSIS_COL_NAME]
     analysis_coll.create_index([("timestamp",  pymongo.DESCENDING), ("sequence_ids",  pymongo.DESCENDING)])
+
+
+def enforce_dates():
+    conn = get_connection()
+    db = conn[DB_NAME]
+    analysis_coll = db[ANALYSIS_COL_NAME]
+    cols = list(filter(lambda n: n.startswith("date_"),map(lambda c: c["field_name"],columns())))
+    for col in cols:
+        analysis_coll.update_many(
+            {
+                "$expr": {
+                    "$eq": [{"$type": f"${col}"}, "string"]
+                }
+            },
+            [
+                {
+                    "$set": {
+                        col: {"$toDate": f"${col}"}
+                    }
+                }
+            ]
+        )

--- a/web/src/SAP/src/controllers/AnalysisController.py
+++ b/web/src/SAP/src/controllers/AnalysisController.py
@@ -2,6 +2,7 @@ import base64
 import json
 import sys
 from datetime import datetime
+import dateutil
 from flask import abort
 from typing import Any, Dict
 from web.src.SAP.generated.models.analysis_query import AnalysisQuery
@@ -270,6 +271,16 @@ def submit_changes(
             # Make sure is allowed to modify that column
             if not col in allowed_cols:
                 raise Forbidden(f"You are not authorized to edit column -{col}-")
+            
+            # Check if any of the dates are invalid dates, and then parse them
+            if col.startswith("date_"):
+                date_str = body[identifier][col]
+                try:
+                    date_val = dateutil.parser.isoparse(date_str)
+                    body[identifier][col] = date_val
+                except:
+                    raise ValueError(f"{date_str} is not a valid date.")
+
     # TODO: Verify that none of these cells are already approved
     update_analysis(body)
     res = dict()

--- a/web/src/SAP/src/services/search/transpiler.py
+++ b/web/src/SAP/src/services/search/transpiler.py
@@ -80,7 +80,7 @@ def structure_range_or_wildcard(field, node):
         if isinstance(coerced, str):
             return check_for_wildcard(field, coerced), False
         elif isinstance(coerced, datetime):
-            return {"$gte": coerced.isoformat(), "$lte": (coerced + timedelta(days=1)).isoformat()}, False
+            return {"$gte": coerced, "$lte": (coerced + timedelta(days=1))}, False
         else:
             return {"$in": [coerced, node.term]}, False
     elif node.term_max is not None or node.term_min is not None:
@@ -90,12 +90,6 @@ def structure_range_or_wildcard(field, node):
         if ((coerced_max is None or isinstance(coerced_max,str)) and (coerced_min is None or isinstance(coerced_min,str))):
             # Both values are strings. It is an id range search
             return id_range_search(field,str(coerced_min),str(coerced_max)), True
-        
-        if coerced_max is not None and isinstance(coerced_max, datetime):
-            coerced_max = coerced_max.isoformat()
-
-        if coerced_min is not None and isinstance(coerced_min, datetime):
-            coerced_min = coerced_min.isoformat()
 
         if coerced_max is None:
             return {"$gte": coerced_min}, False


### PR DESCRIPTION
Denne fix sørger for at alt data bruger ordentlige datoer. Både som migration og ved ændring af data.

Problemet på test er at søge mekanismen antager datoer er en iso string, men det er kun i vores "lokale" testdata at dette er sandt. Test og prod har ordentlige datoer. Denne PR omdanner derfor alle datoer til ordentligte datoer og søger nu kun efter ordentlige datoer.