### PR TITLE
fix: updated microreact

### DIFF
--- a/microreact/Dockerfile
+++ b/microreact/Dockerfile
@@ -8,6 +8,8 @@ COPY ./sofi-mr-server /app/
 
 WORKDIR /app
 
+RUN git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+
 # install produciton deps
 RUN npm install --omit=dev
 

--- a/microreact/Dockerfile
+++ b/microreact/Dockerfile
@@ -8,7 +8,8 @@ COPY ./sofi-mr-server /app/
 
 WORKDIR /app
 
-RUN git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+RUN find . -name package.json -exec sed -i \
+  's#ssh://git@github.com/hasankzl/htmlsvg.git#https://github.com/hasankzl/htmlsvg/archive/refs/heads/main.tar.gz#g' {} \;
 
 # install produciton deps
 RUN npm install --omit=dev

--- a/microreact/Dockerfile
+++ b/microreact/Dockerfile
@@ -9,7 +9,7 @@ COPY ./sofi-mr-server /app/
 WORKDIR /app
 
 RUN find . -name package.json -exec sed -i \
-  's#ssh://git@github.com/hasankzl/htmlsvg.git#https://github.com/hasankzl/htmlsvg/archive/refs/heads/main.tar.gz#g' {} \;
+  's#"htmlsvg": "github:hasankzl/htmlsvg"#"htmlsvg": "https://github.com/hasankzl/htmlsvg/archive/refs/heads/main.tar.gz"#g' {} \;
 
 # install produciton deps
 RUN npm install --omit=dev


### PR DESCRIPTION
Opdaterer microreact submodul. Siden microreact-viewer tilføjer htmlsvg som direkte github dependency kan vi ikke pull i vores build container, så vi bliver nødt til at search/replace med en tar fil. Ret nederen løsning men ved ikke hvad man ellers kan gøre.