### PR TITLE
Search bar history fix

### DIFF
--- a/app/src/app/analysis/analysis-page.tsx
+++ b/app/src/app/analysis/analysis-page.tsx
@@ -97,7 +97,7 @@ import { UseApprovableColumns } from "./analysis-utils";
 const PRIMARY_APPROVAL_FIELDS = ["st_final", "qc_final"];
 const DEFAULT_PAGE_SIZE = 200;
 
-export type SearchQuery = AnalysisQuery & { clearAllFields?: boolean };
+export type SearchQuery = AnalysisQuery & { clearAllFields?: boolean, clickedInHistory?: boolean };
 
 let prevSearchTerms: Set<string> = new Set(); // NEEDS to be outside the react component to prevent un-needed rerender
 
@@ -625,7 +625,7 @@ export default function AnalysisPage() {
       dispatch({ type: "RESET/Analysis" });
       setLastSearchQuery(newQ);
       setLastSearchWs(workspace);
-      appendToSearchHistory(newExpression, searchString);
+      appendToSearchHistory(newExpression, searchString, q.clickedInHistory || false);
 
       const searchingWithWs = workspace && workspace.id !== "temp-workspace";
 

--- a/app/src/app/analysis/search/analysis-search.tsx
+++ b/app/src/app/analysis/search/analysis-search.tsx
@@ -95,7 +95,12 @@ const AnalysisSearch = (props: AnalysisSearchProps) => {
   ]);
 
 
-  const historyCB = useCallback(() => {
+  const historyCB = useCallback((clickedInHistory: boolean) => {
+    if (!clickedInHistory) {
+      // Only replace the search string when clicked in history
+      
+      return;
+    }
     const history = getSearchHistory();
     if (history.length === 0) return;
 

--- a/app/src/app/analysis/search/search-history.tsx
+++ b/app/src/app/analysis/search/search-history.tsx
@@ -62,7 +62,7 @@ const SearchHistoryMenu = (props: {
               icon={<SearchIcon />}
               ml="1"
               onClick={() =>
-                onSearchChange({ expression: s.query, clearAllFields: true }, s.searchString)
+                onSearchChange({ expression: s.query, clearAllFields: true, clickedInHistory: true }, s.searchString)
               }
               style={{ margin: "4px" }}
             />

--- a/app/src/app/analysis/search/search-utils.ts
+++ b/app/src/app/analysis/search/search-utils.ts
@@ -1,3 +1,4 @@
+import { truncateSync } from "fs";
 import { useEffect } from "react";
 import {
   ApprovalStatus,
@@ -336,8 +337,8 @@ export const checkExpressionEquality = (
   return true;
 };
 
-export const cleanExpression = (expr?: QueryExpression |null) => {
-  if (expr === undefined || expr === null  || Object.keys(expr).length === 0) {
+export const cleanExpression = (expr?: QueryExpression | null) => {
+  if (expr === undefined || expr === null || Object.keys(expr).length === 0) {
     return null
   }
 
@@ -356,7 +357,7 @@ export const cleanExpression = (expr?: QueryExpression |null) => {
       }
     }
     if (left || right) {
-      if (expr.operator === QueryOperator.AND ||expr.operator === QueryOperator.OR) {
+      if (expr.operator === QueryOperator.AND || expr.operator === QueryOperator.OR) {
         return left || right
       } else {
         return {
@@ -375,10 +376,10 @@ export const cleanExpression = (expr?: QueryExpression |null) => {
   return null;
 }
 
-export const mergeExpressions = (operator: QueryOperator, left: QueryOperand |null, right: QueryOperand |null): QueryExpression => {
+export const mergeExpressions = (operator: QueryOperator, left: QueryOperand | null, right: QueryOperand | null): QueryExpression => {
   const cleanLeft = cleanExpression(left);
   const cleanRight = cleanExpression(right);
-  if (cleanLeft && cleanRight ) {
+  if (cleanLeft && cleanRight) {
     return {
       operator,
       left: cleanLeft,
@@ -400,24 +401,24 @@ export const mergeExpressions = (operator: QueryOperator, left: QueryOperand |nu
 
 const extractAnds = (expr: QueryExpression): QueryExpression[] => {
   if ("left" in expr && "right" in expr) {
-    const operator  = expr.operator || QueryOperator.AND;
+    const operator = expr.operator || QueryOperator.AND;
 
     if (operator === QueryOperator.AND) {
-      return [...extractAnds(expr.left),...extractAnds(expr.right)]
+      return [...extractAnds(expr.left), ...extractAnds(expr.right)]
     }
   }
   return [expr];
 }
 
-export const dedupExpression = (expr: QueryExpression):QueryExpression => {
+export const dedupExpression = (expr: QueryExpression): QueryExpression => {
   if ("left" in expr && "right" in expr) {
-    const operator  = expr.operator || QueryOperator.AND;
+    const operator = expr.operator || QueryOperator.AND;
     if (operator === QueryOperator.AND) {
       const operands = extractAnds(expr).map(dedupExpression);
 
-      const deduppedOperands = operands.filter((o1,i) => !operands.slice(i+1).find(o2 => o1 !== o2 && checkExpressionEquality(o1,o2)))
-      
-      return deduppedOperands.reduce((a,b) => mergeExpressions(QueryOperator.AND,a,b))
+      const deduppedOperands = operands.filter((o1, i) => !operands.slice(i + 1).find(o2 => o1 !== o2 && checkExpressionEquality(o1, o2)))
+
+      return deduppedOperands.reduce((a, b) => mergeExpressions(QueryOperator.AND, a, b))
 
     }
   }
@@ -462,9 +463,26 @@ export const buildQueryFromFilters = (
   return createAndExpression(expressions);
 };
 
+const is_temp_ws_search = (query: QueryExpression | QueryOperand | null | undefined): boolean => {
+
+  if (!query) {
+    return false;
+  }
+
+  if (query.left || query.right) {
+    return is_temp_ws_search(query.left) || is_temp_ws_search(query.right)
+  }
+  return "field" in query && query.field === "_id";
+}
+
 export const appendToSearchHistory = (query: QueryExpression, searchString: string, clickedInHistory: boolean) => {
   if (recurseSearchTree(query).length == 0) {
     // Ignore empty searches
+    return;
+  }
+
+  // Ignore searched made inside a temp workspace
+  if (is_temp_ws_search(query)) {
     return;
   }
 
@@ -478,7 +496,7 @@ export const appendToSearchHistory = (query: QueryExpression, searchString: stri
     existing.timestamp = new Date().toISOString();
     if (!existing.searchString) {
       // If the old history item was made before searchString was a part of history, we need to use the most recent one
-      existing.searchString = searchString; 
+      existing.searchString = searchString;
     }
     saveSearchHistory([existing, ...withoutExisting]);
   } else {

--- a/app/src/app/analysis/search/search-utils.ts
+++ b/app/src/app/analysis/search/search-utils.ts
@@ -463,14 +463,14 @@ export const buildQueryFromFilters = (
   return createAndExpression(expressions);
 };
 
-const is_temp_ws_search = (query: QueryExpression | QueryOperand | null | undefined): boolean => {
+const isTempWSSearch = (query: QueryExpression | QueryOperand | null | undefined): boolean => {
 
   if (!query) {
     return false;
   }
 
   if (query.left || query.right) {
-    return is_temp_ws_search(query.left) || is_temp_ws_search(query.right)
+    return isTempWSSearch(query.left) || isTempWSSearch(query.right)
   }
   return "field" in query && query.field === "_id";
 }
@@ -482,7 +482,7 @@ export const appendToSearchHistory = (query: QueryExpression, searchString: stri
   }
 
   // Ignore searched made inside a temp workspace
-  if (is_temp_ws_search(query)) {
+  if (isTempWSSearch(query)) {
     return;
   }
 

--- a/app/src/app/analysis/search/search-utils.ts
+++ b/app/src/app/analysis/search/search-utils.ts
@@ -31,20 +31,22 @@ export const getSearchHistory = () => {
   return history;
 };
 
-let callbacks = [];
 
-const registerHistoryCB = (cb: () => void) => {
+type HistoryCB = (clickedInHistory: boolean) => void;
+let callbacks: HistoryCB[] = [];
+
+const registerHistoryCB = (cb: HistoryCB) => {
   callbacks.push(cb);
 };
-const deRegisterHistoryCB = (cb: () => void) => {
+const deRegisterHistoryCB = (cb: HistoryCB) => {
   callbacks = callbacks.filter((c) => c !== cb);
 };
 /// THIS NEEDS THE CALLBACK TO BE STABLE! Otherwise it will deregister and reregister on every render
-export const useHistoryCB = (cb: () => void, executeInitially: boolean) => {
+export const useHistoryCB = (cb: HistoryCB, executeInitially: boolean) => {
   useEffect(() => {
     registerHistoryCB(cb);
     if (executeInitially) {
-      cb()
+      cb(false)
     }
     return () => deRegisterHistoryCB(cb);
   }, [cb, executeInitially])
@@ -63,7 +65,7 @@ export const setPinned = (item: SearchItem, pinned: boolean) => {
     }
   });
   saveSearchHistory(history);
-  callbacks.forEach((cb) => cb());
+  callbacks.forEach((cb) => cb(false));
 };
 
 export const recurseSearchTree = (
@@ -460,7 +462,7 @@ export const buildQueryFromFilters = (
   return createAndExpression(expressions);
 };
 
-export const appendToSearchHistory = (query: QueryExpression, searchString: string) => {
+export const appendToSearchHistory = (query: QueryExpression, searchString: string, clickedInHistory: boolean) => {
   if (recurseSearchTree(query).length == 0) {
     // Ignore empty searches
     return;
@@ -499,5 +501,5 @@ export const appendToSearchHistory = (query: QueryExpression, searchString: stri
     saveSearchHistory(newHistory);
   }
 
-  callbacks.forEach((c) => c());
+  callbacks.forEach((c) => c(clickedInHistory));
 };


### PR DESCRIPTION
Fikser en bug hvor den fejlagtigt ville tro at der er blevet trykket på et felt i historikken og hentede søgefelt teksten, selv når der ikke er blevet trykket i historikken.

Det er fikset ved explicit at tjekke om der er blevet trykker i historikken, eller bare lavet en normal søgning,


Fikser også at temp workspace "_id" søgninger ikke kommer med i søge historikken.